### PR TITLE
Update package.json (keyword homebridge-plugin)

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "ESP8266 based IR Blaster for HomeBridge: https://github.com/nfarina/homebridge",
   "license": "ISC",
   "keywords": [
+    "homebridge-plugin",
     "esp8266"
   ],
   "scripts": {


### PR DESCRIPTION
Reintroduction of keyword "homebridge-plugin" to make the plugin work in Homebridge v1.8.5

## :recycle: Current situation

After removal of the keyword "homebridge-plugin", the plugin is not recognized anymore by Homebridge v1.8.5

## :bulb: Proposed solution

Reintroduce the keyword to make the plugin work again.